### PR TITLE
chore: improvements from PECAN+ 2025

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,6 @@
 *.7z filter=lfs diff=lfs merge=lfs -text
 *.zip.00* filter=lfs diff=lfs merge=lfs -text
 *.7z.00* filter=lfs diff=lfs merge=lfs -text
+*.AppImage filter=lfs diff=lfs merge=lfs -text
+*.exe filter=lfs diff=lfs merge=lfs -text
 *.yml linguist-detectable

--- a/.github/ISSUE_TEMPLATE/submit-challenge.yml
+++ b/.github/ISSUE_TEMPLATE/submit-challenge.yml
@@ -20,7 +20,13 @@ body:
   - type: input
     attributes:
       label: Author
-      description: Supports markdown
+      description: Name or username for players to see
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Email
+      description: Only used if the organisers need to contact you. Please note, this email address will be visible to challenge authors and reviewers
     validations:
       required: true
   - type: textarea
@@ -48,7 +54,7 @@ body:
   - type: textarea
     attributes:
       label: Writeup
-      placeholder: Describe the intended solution to your challenge here. Avoid using markdown subtitles (##)
+      placeholder: Describe the intended solution to your challenge here. Please don't use markdown headings, it breaks the automation (sorry!)
     validations:
       required: true
   - type: checkboxes

--- a/.github/schema.yml
+++ b/.github/schema.yml
@@ -105,6 +105,8 @@ properties:
       - type: string
       - type: object
         properties:
+          title:
+            type: string
           content:
             type: string
           cost:
@@ -112,9 +114,20 @@ properties:
             minimum: 0
 
   requirements:
-    type: array
-    items:
-      type: string
+    oneOf:
+    - type: array
+      items:
+        type: string
+    - type: object
+      properties:
+        prerequisites:
+          type: array
+          items:
+            type: string
+        anonymize:
+          type: boolean
+  next:
+    type: string
 
   state:
     type: string

--- a/.github/workflows/create.yml
+++ b/.github/workflows/create.yml
@@ -4,9 +4,12 @@ on:
   issues:
     types:
       - opened
+      - edited
 
 jobs:
   main:
+    # rerun automation on edits, but only by trusted users to limit git history noise
+    if: github.event.action == 'opened' || github.actor == github.repository_owner
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           shopt -s globstar
           for chal in ${{ steps.changed.outputs.all_changed_and_modified_files }}; do
-            ctf challenge lint $chal --flag_format=${{ vars.FLAG_PREFIX || 'ctf{' }}}
+            ctf challenge lint $chal --skip_hadolint --flag_format=${{ vars.FLAG_PREFIX || 'ctf{' }}} --
           done
 
       # TODO support custom connection_info in ctfcli healthcheck

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 .ctf/
 .devcontainer/
+venv/
+.env
+.DS_Store
+__pycache__
+.vs
+bin
+obj
+packages
+publish
+dist
+node_modules


### PR DESCRIPTION
Ports the generic infrastructure improvements made during PECAN+ 2025 (ECUComputingAndSecurity/PeCanCTF-2025-Public) back into the template. Event-specific changes (flag prefix, event categories, renovate config, ctfcli pin) were deliberately left out.

## Changes

- **`.github/schema.yml`**: support newer ctfcli challenge spec features — hint objects with `title`, the `next` field (used in production for the Doors / Full Stack Reconnaissance / Honey Market chains), and the object form of `requirements` with `prerequisites`/`anonymize`. Validated against the released PECAN 2025 challenges.
- **`.github/workflows/create.yml`**: rerun the issue-to-PR automation when an issue is `edited`, guarded to `github.repository_owner` so arbitrary edits don't churn branches. PECAN hardcoded a username here; this generalises it (note: on org-owned repos the actor never equals the owner, so edit reruns are effectively owner-only on personal repos — happy to swap in a different trust check if preferred).
- **`.github/workflows/tests.yml`**: lint with `--skip_hadolint` and a terminating `--`, as used in production during the event. Drop `--skip_hadolint` if you'd rather keep Dockerfile linting in the template default.
- **Issue form**: collect an author contact email, clarify that Author is player-visible, and warn that markdown headings break the writeup automation.
- **`.gitattributes`**: track `*.AppImage` and `*.exe` in LFS (PECAN shipped an Electron AppImage challenge).
- **`.gitignore`**: common editor/build/dependency artifacts (`venv/`, `.env`, `.DS_Store`, `__pycache__`, `node_modules`, .NET outputs).

## Not ported (event-specific)

- `pecan{` flag default and extra categories (geospatial, indigenous, windows) in the issue form
- `renovate.json` (`config:recommended` vs the template's `github>pl4nty/.github`)
- `ctfcli==0.1.4` pin (template tracks git main)
- Action version differences — the template is already ahead via Renovate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnk3Q7Yu7RqvpGzbh3MXYf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lnk3Q7Yu7RqvpGzbh3MXYf)_